### PR TITLE
Fix groovy setup in readme (#10)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ After applying the plugin, configure the plugin by adding a `scabbard` block:
 
 ```Groovy tab=
 scabbard {
-    enabled = true
+    enabled true
 }
 ```
 


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## Description
Readme uses " enabled = true" instead of " enabled true" for groovy setup.
