### PR TITLE
Make missing processor log just debug

### DIFF
--- a/scabbard-gradle-plugin/src/main/kotlin/dev/arunkumar/scabbard/gradle/processor/ScabbardProcessorManager.kt
+++ b/scabbard-gradle-plugin/src/main/kotlin/dev/arunkumar/scabbard/gradle/processor/ScabbardProcessorManager.kt
@@ -30,7 +30,7 @@ internal class ScabbardProcessorManager(private val scabbardSpec: DefaultScabbar
           ANNOTATION_PROCESSOR,
           scabbardDependency
         )
-        else -> project.logger.error("Neither $ANNOTATION_PROCESSOR or $KAPT was found in project")
+        else -> project.logger.debug("Neither $ANNOTATION_PROCESSOR or $KAPT was found in project")
       }
     } else {
       //TODO(arun) Manually remove the dependency? It is possible for the dep to be added without plugin


### PR DESCRIPTION
## Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## Description
<!--- Describe your changes in detail -->

Right now, it's not possible to try to configure scabbard at a root project level in a way that's mindful of dependencies. That is to say - it's too late to apply its plugin if we wait until dependencies are resolved, so we're eagerly adding it with the expectation that it will no-op if no annotation processing is run. This comes with an unfortunate side effect due to this noisy log though, and this PR proposes making it a debug log since the project should just no-op without it.

![image](https://user-images.githubusercontent.com/1361086/71613847-95591500-2b76-11ea-9e58-9759bd663f76.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See description

## How did you test it?

It's a log print, so none

## Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing on CI

## Next steps


None

## Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
