### PR TITLE
Support Dagger missing binding visualization in console error messages.

### DIFF
--- a/.idea/runConfigurations/Spotless_Apply.xml
+++ b/.idea/runConfigurations/Spotless_Apply.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Spotless Apply" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="spotlessApply" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/scabbard-idea-plugin/build.gradle
+++ b/scabbard-idea-plugin/build.gradle
@@ -19,6 +19,7 @@ tasks.withType(KotlinCompile).configureEach {
 
 dependencies {
   testImplementation "junit:junit:${versions.junit}"
+  testImplementation "com.google.truth:truth:${versions.truth}"
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/JavaComponentToDaggerGraphLineMarker.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/JavaComponentToDaggerGraphLineMarker.kt
@@ -18,7 +18,7 @@ class JavaComponentToDaggerGraphLineMarker : RelatedItemLineMarkerProvider() {
         val graphLineMarker = prepareDaggerComponentLineMarkerWithFileName(
           element = element,
           componentName = psiClass.name!!,
-          fileName = qualifiedName
+          componentFqcn = qualifiedName
         )
         graphLineMarker?.let { result.add(graphLineMarker) }
       }

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/KotlinComponentToDaggerGraphLineMarker.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/KotlinComponentToDaggerGraphLineMarker.kt
@@ -26,7 +26,7 @@ class KotlinComponentToDaggerGraphLineMarker : RelatedItemLineMarkerProvider() {
             val graphLineMarker = prepareDaggerComponentLineMarkerWithFileName(
               element = element,
               componentName = componentName!!,
-              fileName = qualifiedName
+              componentFqcn = qualifiedName
             )
             graphLineMarker?.let { result.add(graphLineMarker) }
           }

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/SearchUtils.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/SearchUtils.kt
@@ -1,0 +1,75 @@
+package dev.arunkumar.scabbard.intellij.dagger
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.psi.PsiFile
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+
+// TODO(arun) create a common package to share these between intellij and processor
+internal const val FULL_GRAPH_PREFIX = "full_"
+internal const val FULL_GRAPH_FILE_NAME = "$FULL_GRAPH_PREFIX%s"
+internal const val TREE_GRAPH_PREFIX = "tree_"
+internal const val TREE_GRAPH_FILE_NAME = "$TREE_GRAPH_PREFIX%s"
+
+internal val FULL_BINDING_GRAPH_FILES = listOf(
+  "$FULL_GRAPH_FILE_NAME.png",
+  "$FULL_GRAPH_FILE_NAME.svg"
+)
+
+internal val COMPONENT_HIERARCHY_GRAPH_FILES = listOf(
+  "$TREE_GRAPH_FILE_NAME.png",
+  "$TREE_GRAPH_FILE_NAME.svg",
+)
+
+internal val DEFAULT_DAGGER_GRAPH_FILES = listOf(
+  "%s.png",
+  "%s.svg",
+)
+
+/**
+ * All known scabbard processor generated files.
+ */
+internal val GENERATED_DAGGER_FILES = (
+  DEFAULT_DAGGER_GRAPH_FILES +
+    COMPONENT_HIERARCHY_GRAPH_FILES +
+    FULL_BINDING_GRAPH_FILES
+  ).asSequence()
+
+/**
+ * Format and sanitize raw file name received from PSI processors.
+ *
+ * Currently replaces inner class markers `$` with `.`
+ */
+private fun String.sanitize(format: String): String {
+  val sanitized = replace("$", ".")
+  return String.format(format, sanitized)
+}
+
+/**
+ * Searches the file system using `FilenameIndex` and returns all matching formats in `GENERATED_DAGGER_FILES`.
+ *
+ * @param project IntelliJ Project
+ * @param componentFqcn The fully qualified class name of Dagger component for which the files should be searched.
+ * @param formats The list of the fill extension format that should be searched. Default `GENERATED_DAGGER_FILES`.
+ */
+internal fun searchGeneratedDaggerFiles(
+  project: Project,
+  componentFqcn: String,
+  formats: Sequence<String> = GENERATED_DAGGER_FILES
+): List<PsiFile> {
+  val scope = GlobalSearchScope.allScope(project)
+  val projectFileIndex = ProjectFileIndex.SERVICE.getInstance(project)
+  return formats
+    .flatMap { fileNameFormat ->
+      // Search by file name
+      FilenameIndex.getFilesByName(
+        project,
+        componentFqcn.sanitize(fileNameFormat),
+        scope
+      ).asSequence()
+    }.filter { psiFile ->
+      // Ensure files present only in sources
+      projectFileIndex.isInSource(psiFile.virtualFile) || true
+    }.toList()
+}

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/ScabbardConsoleFilterProvider.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/ScabbardConsoleFilterProvider.kt
@@ -10,6 +10,6 @@ import dev.arunkumar.scabbard.intellij.dagger.console.filters.MissingBindingFilt
  */
 class ScabbardConsoleFilterProvider : ConsoleFilterProvider {
   override fun getDefaultFilters(project: Project): Array<Filter> {
-    return arrayOf(MissingBindingFilter())
+    return arrayOf(MissingBindingFilter(project))
   }
 }

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/ScabbardConsoleFilterProvider.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/ScabbardConsoleFilterProvider.kt
@@ -1,0 +1,15 @@
+package dev.arunkumar.scabbard.intellij.dagger.console
+
+import com.intellij.execution.filters.ConsoleFilterProvider
+import com.intellij.execution.filters.Filter
+import com.intellij.openapi.project.Project
+import dev.arunkumar.scabbard.intellij.dagger.console.filters.MissingBindingFilter
+
+/**
+ * [ConsoleFilterProvider] that adds links generated images by parsing console logs
+ */
+class ScabbardConsoleFilterProvider : ConsoleFilterProvider {
+  override fun getDefaultFilters(project: Project): Array<Filter> {
+    return arrayOf(MissingBindingFilter())
+  }
+}

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/ScabbardConsoleFilterProvider.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/ScabbardConsoleFilterProvider.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.project.Project
 import dev.arunkumar.scabbard.intellij.dagger.console.filters.MissingBindingFilter
 
 /**
- * [ConsoleFilterProvider] that adds links generated images by parsing console logs
+ * [ConsoleFilterProvider] that adds links to generated images by parsing console  logs
  */
 class ScabbardConsoleFilterProvider : ConsoleFilterProvider {
   override fun getDefaultFilters(project: Project): Array<Filter> {

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/Common.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/Common.kt
@@ -1,0 +1,12 @@
+package dev.arunkumar.scabbard.intellij.dagger.console.filters
+
+interface ConsoleResult {
+  val highlightStartOffset: Int
+  val highlightEndOffset: Int
+}
+
+data class DaggerComponent(
+  override val highlightStartOffset: Int,
+  override val highlightEndOffset: Int,
+  val name: String
+) : ConsoleResult

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/LinkResultExtractor.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/LinkResultExtractor.kt
@@ -4,6 +4,9 @@ import com.intellij.execution.filters.Filter
 import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiShortNamesCache
+import com.intellij.util.PsiNavigateUtil
+import dev.arunkumar.scabbard.intellij.dagger.FULL_BINDING_GRAPH_FILES
+import dev.arunkumar.scabbard.intellij.dagger.searchGeneratedDaggerFiles
 
 interface LinkResultExtractor {
   fun extract(daggerComponent: DaggerComponent): Filter.Result?
@@ -18,6 +21,21 @@ class DefaultLinkExtractor(private val project: Project) : LinkResultExtractor {
       .firstOrNull()
       ?.let { psiClass ->
         // Create Filter Result
+        val componentFqcn = psiClass.qualifiedName!!
+        val matchedFiles = searchGeneratedDaggerFiles(
+          project = project,
+          componentFqcn = componentFqcn,
+          formats = FULL_BINDING_GRAPH_FILES.asSequence() // Missing binding will be only present in full binding graph
+        )
+        if (matchedFiles.isNotEmpty()) {
+          val fullGraphFile = matchedFiles.first()
+          return Filter.Result(
+            daggerComponent.highlightStartOffset,
+            daggerComponent.highlightEndOffset
+          ) {
+            PsiNavigateUtil.navigate(fullGraphFile)
+          }
+        }
       }
     return null
   }

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/LinkResultExtractor.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/LinkResultExtractor.kt
@@ -1,0 +1,24 @@
+package dev.arunkumar.scabbard.intellij.dagger.console.filters
+
+import com.intellij.execution.filters.Filter
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiShortNamesCache
+
+interface LinkResultExtractor {
+  fun extract(daggerComponent: DaggerComponent): Filter.Result?
+}
+
+class DefaultLinkExtractor(private val project: Project) : LinkResultExtractor {
+  override fun extract(daggerComponent: DaggerComponent): Filter.Result? {
+    // Find the class
+    PsiShortNamesCache
+      .getInstance(project)
+      .getClassesByName(daggerComponent.name, GlobalSearchScope.allScope(project))
+      .firstOrNull()
+      ?.let { psiClass ->
+        // Create Filter Result
+      }
+    return null
+  }
+}

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/MissingBindingComponentExtractor.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/MissingBindingComponentExtractor.kt
@@ -1,7 +1,5 @@
 package dev.arunkumar.scabbard.intellij.dagger.console.filters
 
-typealias DaggerComponent = String
-
 interface MissingBindingComponentExtractor {
   fun extract(line: String, entireLength: Int): Set<DaggerComponent>
 }
@@ -20,6 +18,7 @@ class DefaultMissingBindingComponentExtractor : MissingBindingComponentExtractor
       return emptySet()
     }
     if (isDaggerLog) {
+      val lineStart = entireLength - line.length
       // Parse the component simple name from dagger component error line
       if (line.contains("{")) {
         val classNameWithModifiers = when {
@@ -32,8 +31,10 @@ class DefaultMissingBindingComponentExtractor : MissingBindingComponentExtractor
           .map { it.trim() }
           .lastOrNull { it.isNotBlank() }
           ?.let { componentName ->
+            val start = line.indexOf(componentName) + lineStart
+            val end = start + componentName.length
             isDaggerLog = false
-            return setOf(componentName)
+            return setOf(DaggerComponent(start, end, componentName))
           }
       }
     }

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/MissingBindingComponentExtractor.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/MissingBindingComponentExtractor.kt
@@ -1,0 +1,42 @@
+package dev.arunkumar.scabbard.intellij.dagger.console.filters
+
+typealias DaggerComponent = String
+
+interface MissingBindingComponentExtractor {
+  fun extract(line: String, entireLength: Int): Set<DaggerComponent>
+}
+
+class DefaultMissingBindingComponentExtractor : MissingBindingComponentExtractor {
+  companion object {
+    private const val DAGGER_MISSING_BINDING = "[Dagger/MissingBinding]"
+    private const val EXTENDS = "extends"
+  }
+
+  private var isDaggerLog = false
+
+  override fun extract(line: String, entireLength: Int): Set<DaggerComponent> {
+    if (line.contains(DAGGER_MISSING_BINDING)) {
+      isDaggerLog = true
+      return emptySet()
+    }
+    if (isDaggerLog) {
+      // Parse the component simple name from dagger component error line
+      if (line.contains("{")) {
+        val classNameWithModifiers = when {
+          line.contains(EXTENDS) -> line.split(EXTENDS).first()
+          else -> line.split("{").first()
+        }
+        // parse class name from string such as "public abstract class AppComponent"
+        classNameWithModifiers
+          .split(" ")
+          .map { it.trim() }
+          .lastOrNull { it.isNotBlank() }
+          ?.let { componentName ->
+            isDaggerLog = false
+            return setOf(componentName)
+          }
+      }
+    }
+    return emptySet()
+  }
+}

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/MissingBindingFilter.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/MissingBindingFilter.kt
@@ -1,13 +1,21 @@
 package dev.arunkumar.scabbard.intellij.dagger.console.filters
 
 import com.intellij.execution.filters.Filter
+import com.intellij.openapi.project.Project
 
 /**
  * [Filter] to create links to Dagger component's full dependency graph by parsing Dagger's
  * MissingBinding error on the console.
  */
-class MissingBindingFilter : Filter {
+class MissingBindingFilter(
+  private val project: Project,
+  private val missingBindingComponentExtractor: MissingBindingComponentExtractor = DefaultMissingBindingComponentExtractor(),
+  private val linkExtractor: LinkResultExtractor = DefaultLinkExtractor(project)
+) : Filter {
   override fun applyFilter(line: String, entireLength: Int): Filter.Result? {
-    return null
+    val components = missingBindingComponentExtractor.extract(line, entireLength)
+    return if (components.isNotEmpty()) {
+      linkExtractor.extract(components.first())
+    } else null
   }
 }

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/MissingBindingFilter.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/MissingBindingFilter.kt
@@ -1,0 +1,13 @@
+package dev.arunkumar.scabbard.intellij.dagger.console.filters
+
+import com.intellij.execution.filters.Filter
+
+/**
+ * [Filter] to create links to Dagger component's full dependency graph by parsing Dagger's
+ * MissingBinding error on the console.
+ */
+class MissingBindingFilter : Filter {
+  override fun applyFilter(line: String, entireLength: Int): Filter.Result? {
+    return null
+  }
+}

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/hilt/JavaHiltAndroidToDaggerGraphLineMarker.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/hilt/JavaHiltAndroidToDaggerGraphLineMarker.kt
@@ -33,7 +33,7 @@ class JavaHiltAndroidToDaggerGraphLineMarker : RelatedItemLineMarkerProvider() {
         val graphLineMarker = prepareDaggerComponentLineMarkerWithFileName(
           element = element,
           componentName = psiClass.name!!,
-          fileName = qualifiedName
+          componentFqcn = qualifiedName
         )
         graphLineMarker?.let { result.add(graphLineMarker) }
       }

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/hilt/JavaHiltCustomComponentToDaggerGraphLineMarker.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/hilt/JavaHiltCustomComponentToDaggerGraphLineMarker.kt
@@ -25,7 +25,7 @@ class JavaHiltCustomComponentToDaggerGraphLineMarker : RelatedItemLineMarkerProv
           val graphLineMarker = prepareDaggerComponentLineMarkerWithFileName(
             element = element,
             componentName = componentClass.name!!,
-            fileName = qualifiedName
+            componentFqcn = qualifiedName
           )
           graphLineMarker?.let { result.add(graphLineMarker) }
         }

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/hilt/KotlinHiltAndroidToDaggerGraphLineMarker.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/hilt/KotlinHiltAndroidToDaggerGraphLineMarker.kt
@@ -42,7 +42,7 @@ class KotlinHiltAndroidToDaggerGraphLineMarker : RelatedItemLineMarkerProvider()
               val graphLineMarker = prepareDaggerComponentLineMarkerWithFileName(
                 element = element,
                 componentName = ktClass.name!!,
-                fileName = qualifiedName
+                componentFqcn = qualifiedName
               )
               graphLineMarker?.let { result.add(graphLineMarker) }
             }

--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/hilt/KotlinHiltCustomComponentToDaggerGraphLineMarker.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/hilt/KotlinHiltCustomComponentToDaggerGraphLineMarker.kt
@@ -37,7 +37,7 @@ class KotlinHiltCustomComponentToDaggerGraphLineMarker : RelatedItemLineMarkerPr
               val graphLineMarker = prepareDaggerComponentLineMarkerWithFileName(
                 element = element,
                 componentName = ktClass.name!!,
-                fileName = qualifiedName
+                componentFqcn = qualifiedName
               )
               graphLineMarker?.let { result.add(graphLineMarker) }
             }

--- a/scabbard-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/scabbard-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -57,12 +57,18 @@
             language="kotlin" />
         <codeInsight.lineMarkerProvider
             implementationClass="dev.arunkumar.scabbard.intellij.dagger.hilt.JavaHiltAndroidToDaggerGraphLineMarker"
-            language="JAVA" />
+            language="JAVA"/>
         <codeInsight.lineMarkerProvider
             implementationClass="dev.arunkumar.scabbard.intellij.dagger.JavaComponentToDaggerGraphLineMarker"
-            language="JAVA" />
+            language="JAVA"/>
         <codeInsight.lineMarkerProvider
             implementationClass="dev.arunkumar.scabbard.intellij.dagger.android.JavaContributesAndroidInjectorLineMarker"
-            language="JAVA" />
+            language="JAVA"/>
+    </extensions>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <consoleFilterProvider
+            implementation="dev.arunkumar.scabbard.intellij.dagger.console.ScabbardConsoleFilterProvider"
+            order="last"/>
     </extensions>
 </idea-plugin>

--- a/scabbard-idea-plugin/src/test/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/DefaultMissingBindingComponentExtractorTest.kt
+++ b/scabbard-idea-plugin/src/test/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/DefaultMissingBindingComponentExtractorTest.kt
@@ -1,0 +1,69 @@
+package dev.arunkumar.scabbard.intellij.dagger.console.filters
+
+import com.google.common.truth.Truth
+import org.junit.Before
+import org.junit.Test
+
+private typealias ConsoleLog = String
+
+class DefaultMissingBindingComponentExtractorTest {
+  private lateinit var missingBindingComponentExtractor: MissingBindingComponentExtractor
+
+  @Before
+  fun setup() {
+    missingBindingComponentExtractor = DefaultMissingBindingComponentExtractor()
+  }
+
+  private fun ConsoleLog.applyTo(
+    missingBindingComponentExtractor: MissingBindingComponentExtractor
+  ) = lineSequence()
+    .map { it.trim() }
+    .flatMap { missingBindingComponentExtractor.extract(it, it.length).asSequence() }
+    .toSet()
+
+  @Test
+  fun `assert dagger component with supertype is extracted from missing binding stream of logs`() {
+    val consoleLog = """
+    |> Task :scabbard-processor:jar UP-TO-DATE
+    |> Task :samples:android-kotlin:kaptGenerateStubsDebugKotlin UP-TO-DATE
+    |
+    |> Task :samples:android-kotlin:kaptDebugKotlin
+    |C:\Users\arunk\AndroidProjects\personal\scabbard\samples\android-kotlin\build\tmp\kapt3\stubs\debug\dev\arunkumar\scabbard\di\AppComponent.java:8: error: [Dagger/MissingBinding] dev.arunkumar.scabbard.di.ProvisionBinding cannot be provided without an @Inject constructor or an @Provides-annotated method.
+    |public abstract interface AppComponent extends dagger.android.AndroidInjector<dev.arunkumar.scabbard.App> {
+    |                ^
+    |      dev.arunkumar.scabbard.di.ProvisionBinding is injected at
+    |          dev.arunkumar.scabbard.App.provisionBinding
+    |      dev.arunkumar.scabbard.App is injected at
+    |          dagger.android.AndroidInjector.inject(T)
+    |  It is also requested at:
+    |      dev.arunkumar.scabbard.di.ComplexMultiBinding(provisionBinding)
+    |> Task :samples:android-kotlin:kaptDebugKotlin FAILED
+""".trimMargin()
+    val daggerComponents = consoleLog.applyTo(missingBindingComponentExtractor)
+    Truth.assertThat(daggerComponents)
+      .containsExactly("AppComponent")
+  }
+
+  @Test
+  fun `assert dagger component without supertype is extracted from missing binding stream of logs`() {
+    val consoleLog = """
+    |> Task :scabbard-processor:jar UP-TO-DATE
+    |> Task :samples:android-kotlin:kaptGenerateStubsDebugKotlin UP-TO-DATE
+    |
+    |> Task :samples:android-kotlin:kaptDebugKotlin
+    |C:\Users\arunk\AndroidProjects\personal\scabbard\samples\android-kotlin\build\tmp\kapt3\stubs\debug\dev\arunkumar\scabbard\di\AppComponent.java:8: error: [Dagger/MissingBinding] dev.arunkumar.scabbard.di.ProvisionBinding cannot be provided without an @Inject constructor or an @Provides-annotated method.
+    |public abstract interface AppComponent  {
+    |                ^
+    |      dev.arunkumar.scabbard.di.ProvisionBinding is injected at
+    |          dev.arunkumar.scabbard.App.provisionBinding
+    |      dev.arunkumar.scabbard.App is injected at
+    |          dagger.android.AndroidInjector.inject(T)
+    |  It is also requested at:
+    |      dev.arunkumar.scabbard.di.ComplexMultiBinding(provisionBinding)
+    |> Task :samples:android-kotlin:kaptDebugKotlin FAILED
+""".trimMargin()
+    val daggerComponents = consoleLog.applyTo(missingBindingComponentExtractor)
+    Truth.assertThat(daggerComponents)
+      .containsExactly("AppComponent")
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,10 +15,8 @@ include "samples:android-kotlin-hilt"
 include "samples:simple-maven"
 include "samples:kotlin-anvil"
 
-
 includeBuild("scabbard-gradle-plugin") {
   dependencySubstitution {
     substitute module("dev.arunkumar:scabbard-gradle-plugin") with project(":")
   }
 }
-


### PR DESCRIPTION
Adds a hyperlink in console log on Dagger Missing Binding error messages. The hyperlink will open the full binding graph image which should contain visualized missing binding information.

![Screenshot 2021-04-25 043718](https://user-images.githubusercontent.com/3940492/115972726-a8b99c00-a582-11eb-998d-81aa974b6887.png)
