### PR TITLE
[Dagger/Missing Binding] Visualization: Support components implementing multiple interfaces.

### DIFF
--- a/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/MissingBindingComponentExtractor.kt
+++ b/scabbard-idea-plugin/src/main/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/MissingBindingComponentExtractor.kt
@@ -8,6 +8,7 @@ class DefaultMissingBindingComponentExtractor : MissingBindingComponentExtractor
   companion object {
     private const val DAGGER_MISSING_BINDING = "[Dagger/MissingBinding]"
     private const val EXTENDS = "extends"
+    private const val IMPLEMENTS = "implements"
   }
 
   private var isDaggerLog = false
@@ -20,9 +21,10 @@ class DefaultMissingBindingComponentExtractor : MissingBindingComponentExtractor
     if (isDaggerLog) {
       val lineStart = entireLength - line.length
       // Parse the component simple name from dagger component error line
-      if (line.contains("{")) {
+      if (line.endsWith("{") || line.endsWith(",")) {
         val classNameWithModifiers = when {
           line.contains(EXTENDS) -> line.split(EXTENDS).first()
+          line.contains(IMPLEMENTS) -> line.split(IMPLEMENTS).first()
           else -> line.split("{").first()
         }
         // parse class name from string such as "public abstract class AppComponent"

--- a/scabbard-idea-plugin/src/test/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/DefaultMissingBindingComponentExtractorTest.kt
+++ b/scabbard-idea-plugin/src/test/kotlin/dev/arunkumar/scabbard/intellij/dagger/console/filters/DefaultMissingBindingComponentExtractorTest.kt
@@ -73,4 +73,23 @@ class DefaultMissingBindingComponentExtractorTest {
     Truth.assertThat(daggerComponents)
       .containsExactly(DaggerComponent(446, 458, "AppComponent"))
   }
+
+  @Test
+  fun `assert dagger hilt component with interface supertype is extracted from missing binding stream of logs`() {
+    val consoleLog = """
+      |> Task :samples:android-kotlin-hilt:kaptDebugKotlin
+      |[WARN] Issue detected with dagger.internal.codegen.ComponentProcessor. Expected 1 originating source file when generating C:\Users\arunk\AndroidProjects\personal\scabbard\samples\android-kotlin-hilt\build\generated\source\kapt\debug\scabbard\full_dev.arunkumar.scabbard.sample.hilt.HiltCustomModule.dot, but detected 0: [].
+      |C:\Users\arunk\AndroidProjects\personal\scabbard\samples\android-kotlin-hilt\build\generated\source\kapt\debug\dev\arunkumar\scabbard\sample\hilt\HiltSampleApp_HiltComponents.java:131: error: [Dagger/MissingBinding] dev.arunkumar.scabbard.sample.hilt.SingletonBinding cannot be provided without an @Inject constructor or an @Provides-annotated method.
+      |  public abstract static class SingletonC implements HiltWrapper_ActivityRetainedComponentManager_ActivityRetainedComponentBuilderEntryPoint,
+      |                         ^
+      |      dev.arunkumar.scabbard.sample.hilt.SingletonBinding is injected at
+      |          dev.arunkumar.scabbard.sample.hilt.HiltSampleApp.singletonBinding
+      |      dev.arunkumar.scabbard.sample.hilt.HiltSampleApp is injected at
+      |          dev.arunkumar.scabbard.sample.hilt.HiltSampleApp_GeneratedInjector.injectHiltSampleApp(dev.arunkumar.scabbard.sample.hilt.HiltSampleApp)
+      |> Task :samples:android-kotlin-hilt:kaptDebugKotlin FAILED
+    """.trimMargin()
+    val daggerComponents = consoleLog.applyTo(missingBindingComponentExtractor)
+    Truth.assertThat(daggerComponents)
+      .containsExactly(DaggerComponent(705, 715, "SingletonC"))
+  }
 }


### PR DESCRIPTION
## Proposed Changes

Pure `{` detection does not work for Dagger components that implement multiple interfaces like `Hilt`. 

## Testing
Unit tests

## Issues Fixed