### PR TITLE
Update Android SDK, AGP, cache gradlew in docker image

### DIFF
--- a/.github/workflows/gradle_docker.yml
+++ b/.github/workflows/gradle_docker.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Prepare gradle cache
         run: |
           export GRADLE_USER_HOME="$(pwd)/docker/cache/.gradle"
+          ./gradlew --version --no-daemon -g $GRADLE_USER_HOME
           ./gradlew resolveDependencies --no-daemon -g $GRADLE_USER_HOME
           cd scabbard-gradle-plugin
           ./gradlew resolveDependencies --no-daemon -g $GRADLE_USER_HOME

--- a/constants.gradle
+++ b/constants.gradle
@@ -1,6 +1,6 @@
 ext {
   versions = [
-    "agp"           : "4.2.1",
+    "agp"           : "4.2.2",
     "androidx"      : [
       "appcompat"            : "1.1.0",
       "core"                 : "1.3.2",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM reactivecircus/android-sdk:v2020_04_26-14-11-07
+FROM rreactivecircus/android-sdk-30
 
 MAINTAINER Arunkumar "hi@arunkumar.dev"
 

--- a/samples/android-kotlin-hilt/build.gradle
+++ b/samples/android-kotlin-hilt/build.gradle
@@ -6,13 +6,12 @@ apply plugin: scabbardGradlePlugin
 apply plugin: "dagger.hilt.android.plugin"
 
 android {
-  compileSdkVersion 29
-  buildToolsVersion "29.0.3"
+  compileSdkVersion 30
 
   defaultConfig {
     applicationId "dev.arunkumar.scabbard.sample.hilt"
     minSdkVersion 21
-    targetSdkVersion 29
+    targetSdkVersion 30
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/samples/android-kotlin/build.gradle
+++ b/samples/android-kotlin/build.gradle
@@ -5,13 +5,12 @@ apply plugin: "kotlin-kapt"
 apply plugin: scabbardGradlePlugin
 
 android {
-  compileSdkVersion 29
-  buildToolsVersion "29.0.3"
+  compileSdkVersion 30
 
   defaultConfig {
     applicationId "dev.arunkumar.scabbard.sample"
     minSdkVersion 21
-    targetSdkVersion 29
+    targetSdkVersion 30
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Proposed Changes

Update Android SDK.
`gradlew` was not getting cached in docker properly, this change hopefully fixes it by explicitly invoking `gradlew --version`.

## Testing
NA

## Issues Fixed